### PR TITLE
Add InventoryItem types for frontend

### DIFF
--- a/expo/ppal/app/(tabs)/pantry.tsx
+++ b/expo/ppal/app/(tabs)/pantry.tsx
@@ -6,16 +6,17 @@ import { MaterialIcons } from '@expo/vector-icons'; // Icons for delete and add 
 import apiClient from '../../src/api/client';
 import { useAuth } from '../../src/context/AuthContext';
 import { useRouter, Redirect } from 'expo-router';
+import { InventoryItem } from '../../src/types/InventoryItem';
 
 export default function PantryScreen() {
   const { userToken, userId, loading, signOut } = useAuth();
   const router = useRouter();
-  const [pantryItems, setPantryItems] = useState<any[]>([]);
+  const [pantryItems, setPantryItems] = useState<InventoryItem[]>([]);
   const [addModalVisible, setAddModalVisible] = useState(false);
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
   const [itemName, setItemName] = useState('');
   const [itemQuantity, setItemQuantity] = useState('');
-  const [selectedItemDetails, setSelectedItemDetails] = useState<any | null>(null);
+  const [selectedItemDetails, setSelectedItemDetails] = useState<InventoryItem | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const { width } = Dimensions.get('window');
   // Images are auto-generated upon item creation via the API
@@ -32,12 +33,12 @@ export default function PantryScreen() {
 
   const fetchPantry = async () => {
     try {
-      const res = await apiClient.get('/pantry/items');
+      const res = await apiClient.get<InventoryItem[]>('/pantry/items');
       console.log('Fetched pantry items:', res.data);
       // Filter active items and map image_url to imageUrl
       const activeItems = res.data
-        .filter((item: any) => item.active)
-        .map((item: any) => ({
+        .filter((item: InventoryItem) => item.active)
+        .map((item: InventoryItem) => ({
           ...item,
           imageUrl: item.image_url || item.imageUrl || null,
         }));
@@ -90,7 +91,7 @@ export default function PantryScreen() {
     );
   };
 
-  const showItemDetails = (item: any) => {
+  const showItemDetails = (item: InventoryItem) => {
     const macros = item.macros || {
       calories: 0,
       protein: 0,

--- a/expo/ppal/src/types/InventoryItem.ts
+++ b/expo/ppal/src/types/InventoryItem.ts
@@ -1,0 +1,34 @@
+export interface InventoryItemMacros {
+  calories?: number;
+  protein?: number;
+  carbohydrates?: number;
+  fiber?: number;
+  sugar?: number;
+  fat?: number;
+  saturated_fat?: number;
+  polyunsaturated_fat?: number;
+  monounsaturated_fat?: number;
+  trans_fat?: number;
+  cholesterol?: number;
+  sodium?: number;
+  potassium?: number;
+  vitamin_a?: number;
+  vitamin_c?: number;
+  calcium?: number;
+  iron?: number;
+}
+
+export interface InventoryItem {
+  id: string;
+  user_id?: string;
+  product_name: string;
+  quantity?: number;
+  upc?: string;
+  macros?: InventoryItemMacros;
+  cost?: number;
+  expiration_date?: string;
+  environmental_impact?: number;
+  image_url?: string | null;
+  imageUrl?: string | null;
+  active: boolean;
+}


### PR DESCRIPTION
## Summary
- define `InventoryItem` and `InventoryItemMacros` interfaces
- use these interfaces in the pantry screen and replace `any` uses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx --yes tsc --noEmit -p expo/ppal/tsconfig.json` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684501e0ce888321acea01165618ffbd