### PR TITLE
Add .env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__*
 
 # Ignore environment variable files
 *.env*
+!api/.env.example
 
 # Ignore database dumps
 *database.json*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ uvicorn app:app --reload --port 8000
 Key environment variables expected by the API include:
 `PANTRY_TABLE_NAME`, `AUTH_TABLE_NAME`, `USDA_API_KEY`, `OPENAI_API_KEY`,
 `SECRET_KEY`, `MACRO_QUEUE_URL`, and `IMAGE_QUEUE_URL`.
+Use the example file at `api/.env.example` as a starting point and copy it to
+`api/.env` when configuring your environment.
 
 ## Working with the Frontend
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Use the platform script at the repo root to install dependencies for both API an
 setup.bat
 ```
 
+An example environment file is provided at `api/.env.example`.
+
 After running the script, copy and configure your environment variables:
 ```bash
 cp api/.env.example api/.env  # or create api/.env

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,22 @@
+# PantryPal API environment variables
+
+# DynamoDB table storing pantry items
+PANTRY_TABLE_NAME=PantryPal
+
+# DynamoDB table storing user authentication data
+AUTH_TABLE_NAME=AuthTable
+
+# USDA FoodData Central API key for macro enrichment
+USDA_API_KEY=your_usda_api_key
+
+# OpenAI API key for recipes and images
+OPENAI_API_KEY=your_openai_api_key
+
+# Secret key for session tokens
+SECRET_KEY=change_me
+
+# AWS SQS URL for macro enrichment jobs
+MACRO_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/macro-queue
+
+# AWS SQS URL for image generation jobs
+IMAGE_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/image-queue


### PR DESCRIPTION
## Summary
- add `api/.env.example` with placeholders
- mention copying the file in `AGENTS.md` and `README`
- track the sample file in gitignore

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: NoCredentialsError, ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_684516be08308321908b36221cf61c14