### PR TITLE
Add swipe UI and recipe like API

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,7 @@ from macros.macro_service import macro_router, enrich_item, enrich_recipe
 from auth.auth_service import auth_router
 from ai.openai_service import openai_router
 from chat.chat_service import chat_router
+from recipes.like_service import recipes_router
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -35,6 +36,7 @@ app.include_router(macro_router, tags=["Macros"])
 app.include_router(auth_router, tags=["Auth"])
 app.include_router(openai_router, tags=["OpenAI"])
 app.include_router(chat_router, tags=["Chats"])
+app.include_router(recipes_router, tags=["Recipes"])
 
 # Add new routes
 app.add_api_route("/roi/metrics", get_roi_metrics, methods=["GET"], tags=["ROI"])

--- a/api/models/models.py
+++ b/api/models/models.py
@@ -161,3 +161,7 @@ class ChatMeta(BaseModel):
     title: str
     updatedAt: str
     length: int
+
+
+class LikedRecipe(BaseModel):
+    recipe_id: str

--- a/api/recipes/like_service.py
+++ b/api/recipes/like_service.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException
+from auth.auth_service import get_user_id_from_token
+from storage.utils import (
+    add_liked_recipe,
+    remove_liked_recipe,
+    read_liked_recipes,
+    read_pantry_items,
+)
+from ai.openai_service import build_recipe_prompt, call_openai
+import json
+
+recipes_router = APIRouter(prefix="/recipes")
+
+@recipes_router.post("/{recipe_id}/like", status_code=204)
+def like_recipe(recipe_id: str, user_id: str = Depends(get_user_id_from_token)):
+    add_liked_recipe(user_id, recipe_id)
+    return None
+
+@recipes_router.delete("/{recipe_id}/like", status_code=204)
+def unlike_recipe(recipe_id: str, user_id: str = Depends(get_user_id_from_token)):
+    remove_liked_recipe(user_id, recipe_id)
+    return None
+
+@recipes_router.get("/recommendations")
+def get_recommendations(user_id: str = Depends(get_user_id_from_token)):
+    items = [it.dict() if hasattr(it, "dict") else it for it in read_pantry_items(user_id)]
+    prompt = build_recipe_prompt(items)
+    try:
+        raw = call_openai(prompt)
+        suggestions = json.loads(raw)
+    except Exception:
+        suggestions = []
+    liked = [r.recipe_id for r in read_liked_recipes(user_id)]
+    return {"liked": liked, "recommendations": suggestions}

--- a/api/tests/test_macros.py
+++ b/api/tests/test_macros.py
@@ -13,6 +13,9 @@ def override_get_user_id_from_token():
 
 app.dependency_overrides[get_user] = override_get_user
 app.dependency_overrides[get_user_id_from_token] = override_get_user_id_from_token
+from macros import macro_service
+from models.models import InventoryItemMacros
+macro_service.query_food_api = lambda name: InventoryItemMacros(protein=1) if name != "NonExistentFood" else None
 
 client = TestClient(app)
 

--- a/api/tests/test_pantry.py
+++ b/api/tests/test_pantry.py
@@ -14,6 +14,10 @@ def override_get_user_id_from_token():
 
 app.dependency_overrides[get_user] = override_get_user
 app.dependency_overrides[get_user_id_from_token] = override_get_user_id_from_token
+from storage import utils
+utils.read_pantry_items = lambda user_id: []
+import pantry.pantry_service as pantry_service
+pantry_service.read_pantry_items = utils.read_pantry_items
 
 client = TestClient(app)
 

--- a/api/tests/test_recipes.py
+++ b/api/tests/test_recipes.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from api.app import app
+import recipes.like_service as like_service
+
+app.dependency_overrides[like_service.get_user_id_from_token] = lambda: "testuser"
+
+like_service.add_liked_recipe = lambda user_id, recipe_id: None
+like_service.remove_liked_recipe = lambda user_id, recipe_id: None
+like_service.read_liked_recipes = lambda user_id: []
+like_service.read_pantry_items = lambda user_id: []
+like_service.call_openai = lambda prompt: '[]'
+
+client = TestClient(app)
+
+def test_like_recipe():
+    resp = client.post("/recipes/1/like")
+    assert resp.status_code == 204
+
+def test_get_recommendations():
+    resp = client.get("/recipes/recommendations")
+    assert resp.status_code == 200
+    assert "recommendations" in resp.json()
+
+

--- a/expo/ppal/app/(tabs)/_layout.tsx
+++ b/expo/ppal/app/(tabs)/_layout.tsx
@@ -6,7 +6,7 @@ export default function TabsLayout() {
     <Tabs screenOptions={{ headerShown: false }}>
       <Tabs.Screen name="pantry" options={{ title: 'Pantry' }} />
       <Tabs.Screen name="chats" options={{ title: 'Chats' }} />
-      <Tabs.Screen name="explore" options={{ title: 'Explore' }} />
+      <Tabs.Screen name="swipe" options={{ title: 'Swipe' }} />
     </Tabs>
   );
 }

--- a/expo/ppal/app/(tabs)/swipe.tsx
+++ b/expo/ppal/app/(tabs)/swipe.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Swiper from 'react-native-deck-swiper';
+import apiClient from '../../src/api/client';
+import { useAuth } from '../../src/context/AuthContext';
+
+interface Card {
+  id: string;
+  title: string;
+}
+
+export default function SwipeScreen() {
+  const { userToken } = useAuth();
+  const [cards, setCards] = useState<Card[]>([]);
+
+  useEffect(() => {
+    if (userToken) {
+      fetchRecs();
+    }
+  }, [userToken]);
+
+  const fetchRecs = async () => {
+    try {
+      const res = await apiClient.get('/recipes/recommendations');
+      setCards(res.data.recommendations || []);
+    } catch (e) {
+      console.error('Failed to fetch recommendations', e);
+    }
+  };
+
+  const likeCard = async (index: number) => {
+    const card = cards[index];
+    if (!card) return;
+    try {
+      await apiClient.post(`/recipes/${card.id}/like`);
+    } catch (e) {
+      console.error('Failed to like recipe', e);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      {cards.length > 0 ? (
+        <Swiper
+          cards={cards}
+          renderCard={(card) => (
+            <View style={styles.card}>
+              <Text style={styles.text}>{card.title}</Text>
+            </View>
+          )}
+          onSwipedRight={likeCard}
+          stackSize={3}
+          cardIndex={0}
+          backgroundColor="#f0f0f0"
+        />
+      ) : (
+        <Text style={{ textAlign: 'center', marginTop: 40 }}>No recipes</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 0.8,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 16,
+    borderColor: '#ccc',
+    borderWidth: 1,
+  },
+  text: {
+    fontSize: 18,
+    textAlign: 'center',
+  },
+});

--- a/expo/ppal/package.json
+++ b/expo/ppal/package.json
@@ -45,6 +45,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
+    "react-native-deck-swiper": "^3.0.0",
     "react-native-markdown-display": "^7.0.2"
   },
   "devDependencies": {

--- a/expo/ppal/src/types/RecipeCard.ts
+++ b/expo/ppal/src/types/RecipeCard.ts
@@ -1,0 +1,4 @@
+export interface RecipeCard {
+  id: string;
+  title: string;
+}


### PR DESCRIPTION
## Summary
- support recipe likes and recommendations
- expose new `/recipes` routes
- add swiper tab on the frontend
- install `react-native-deck-swiper`
- patch tests for offline execution
- ensure new endpoints are covered by tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684521223f8c83218f953e8a26d7b0a3